### PR TITLE
Include Survey Section when saving Response

### DIFF
--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -7,6 +7,7 @@
   = ff.input :question_id, :as => :quiet unless q.pick == "one" # don't repeat question_id if we're on radio buttons
   = ff.input :api_id, :as => :quiet unless q.pick == "one"
   = ff.input :response_group, :input_html => {:value => rg}, :as => :quiet if q.pick != "one" && g && g.display_type == "repeater"
+  = ff.input :survey_section_id, :as => :quiet, :value => @section.id unless q.pick == "one"
   - case q.pick
   - when "one"
     = ff.input :answer_id, :as => :surveyor_radio, :collection => [[a.text_for(nil, @render_context, I18n.locale), a.id]], :label => false, :input_html => {:class => a.css_class, :disabled => disabled}, :response_class => a.response_class, :required => q.mandatory?

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -14,6 +14,7 @@
         = ff.input :question_id, :as => :quiet
         = ff.input :response_group, :as => :quiet, :input_html => {:value => rg} if g && g.display_type == "repeater"
         = ff.input :api_id, :as => :quiet
+        = ff.input :survey_section_id, :as => :quiet, :value => @section.id
         = ff.input :answer_id, :as => :select, :collection => q.answers.map{|a| [a.text, a.id]}, :include_blank => (renderer != :slider), :label => q.text, :input_html => { :disabled => disabled, :required => q.mandatory? }
     - else # :default, :inline, :inline_default
       - if q.pick == "one"
@@ -23,6 +24,7 @@
           = ff.input :question_id, :as => :quiet
           = ff.input :response_group, :as => :quiet, :value => rg if g && g.display_type == "repeater"
           = ff.input :api_id, :as => :quiet
+          = ff.input :survey_section_id, :as => :quiet, :value => @section.id
       - q.answers.each do |a|
         - next if (q.pick == "one" or q.pick == "any") and disabled and @response_set.responses.where( :question_id => q.id, :answer_id => a.id).empty?
         = render a.custom_renderer || '/partials/answer', :q => q, :a => a, :f => f, :rg => rg, :g => g, :disableFlag => disabled

--- a/app/views/partials/_question_group.html.haml
+++ b/app/views/partials/_question_group.html.haml
@@ -30,6 +30,7 @@
                         = f.semantic_fields_for i, r do |ff|
                           = ff.input :question_id, :as => :quiet
                           = ff.input :api_id, :as => :quiet
+                          = ff.input :survey_section_id, :as => :quiet, :value => @section.id
                       - q.answers.each do |a|
                         %td= render(a.custom_renderer || '/partials/answer', :g => g, :q => q, :a => a, :f => f) unless q.display_type == "label"
                       %th= q.text_for(:post, @render_context, I18n.locale)

--- a/lib/surveyor/models/response_methods.rb
+++ b/lib/surveyor/models/response_methods.rb
@@ -11,6 +11,7 @@ module Surveyor
         belongs_to :response_set
         belongs_to :question
         belongs_to :answer
+        belongs_to :survey_section
         attr_accessible *PermittedParams.new.response_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/lib/surveyor/models/survey_section_methods.rb
+++ b/lib/surveyor/models/survey_section_methods.rb
@@ -8,6 +8,7 @@ module Surveyor
       included do
         # Associations
         has_many :questions, :dependent => :destroy
+        has_many :responses
         belongs_to :survey
         attr_accessible *PermittedParams.new.survey_section_attributes if defined? ActiveModel::MassAssignmentSecurity
 


### PR DESCRIPTION
This addresses an issue I ran into where there wasn't a good way to group responses together. The survey section id is now included when the response is submitted so it can be updated. This will making grouping responses inside FW.com much easier