### PR TITLE
[SD-9961] Rails 5.2 fixes

### DIFF
--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -7,7 +7,7 @@
   = ff.input :question_id, :as => :quiet unless q.pick == "one" # don't repeat question_id if we're on radio buttons
   = ff.input :api_id, :as => :quiet unless q.pick == "one"
   = ff.input :response_group, :input_html => {:value => rg}, :as => :quiet if q.pick != "one" && g && g.display_type == "repeater"
-  = ff.input :survey_section_id, :as => :quiet, :value => @section.id unless q.pick == "one"
+  = ff.input :survey_section_id, :as => :quiet, :input_html => { :value => @section.id } unless q.pick == "one"
   - case q.pick
   - when "one"
     = ff.input :answer_id, :as => :surveyor_radio, :collection => [[a.text_for(nil, @render_context, I18n.locale), a.id]], :label => false, :input_html => {:class => a.css_class, :disabled => disabled}, :response_class => a.response_class, :required => q.mandatory?

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -14,7 +14,7 @@
         = ff.input :question_id, :as => :quiet
         = ff.input :response_group, :as => :quiet, :input_html => {:value => rg} if g && g.display_type == "repeater"
         = ff.input :api_id, :as => :quiet
-        = ff.input :survey_section_id, :as => :quiet, :value => @section.id
+        = ff.input :survey_section_id, :as => :quiet, :input_html => { :value => @section.id }
         = ff.input :answer_id, :as => :select, :collection => q.answers.map{|a| [a.text, a.id]}, :include_blank => (renderer != :slider), :label => q.text, :input_html => { :disabled => disabled, :required => q.mandatory? }
     - else # :default, :inline, :inline_default
       - if q.pick == "one"
@@ -22,9 +22,9 @@
         - i = response_idx  # increment the response index since the answer partial skips for q.pick == one
         = f.semantic_fields_for i, r do |ff|
           = ff.input :question_id, :as => :quiet
-          = ff.input :response_group, :as => :quiet, :value => rg if g && g.display_type == "repeater"
+          = ff.input :response_group, :as => :quiet, :input_html => { :value => rg } if g && g.display_type == "repeater"
           = ff.input :api_id, :as => :quiet
-          = ff.input :survey_section_id, :as => :quiet, :value => @section.id
+          = ff.input :survey_section_id, :as => :quiet, :input_html => { :value => @section.id }
       - q.answers.each do |a|
         - next if (q.pick == "one" or q.pick == "any") and disabled and @response_set.responses.where( :question_id => q.id, :answer_id => a.id).empty?
         = render a.custom_renderer || '/partials/answer', :q => q, :a => a, :f => f, :rg => rg, :g => g, :disableFlag => disabled

--- a/app/views/partials/_question_group.html.haml
+++ b/app/views/partials/_question_group.html.haml
@@ -30,7 +30,7 @@
                         = f.semantic_fields_for i, r do |ff|
                           = ff.input :question_id, :as => :quiet
                           = ff.input :api_id, :as => :quiet
-                          = ff.input :survey_section_id, :as => :quiet, :value => @section.id
+                          = ff.input :survey_section_id, :as => :quiet, input_html: { :value => @section.id }
                       - q.answers.each do |a|
                         %td= render(a.custom_renderer || '/partials/answer', :g => g, :q => q, :a => a, :f => f) unless q.display_type == "label"
                       %th= q.text_for(:post, @render_context, I18n.locale)

--- a/lib/surveyor/surveyor_controller_methods.rb
+++ b/lib/surveyor/surveyor_controller_methods.rb
@@ -133,7 +133,7 @@ module Surveyor
         if @response_set
           saved = true
           if params[:r]
-            saved = @response_set.update_from_ui_hash(params.require(:r).permit!)
+            saved = @response_set.update_from_ui_hash(params.require(:r).permit!.to_unsafe_hash)
           end
           if params[:finish]
             @response_set.complete!


### PR DESCRIPTION
- Fix deprecated parameter hash access.
- Fix deprecated `:value` usage.